### PR TITLE
Use class selector instead of element selectors

### DIFF
--- a/src/components/2-GlobalSelectors/GlobalSelectors.css
+++ b/src/components/2-GlobalSelectors/GlobalSelectors.css
@@ -7,7 +7,7 @@
   max-width: 400px;
 }
 
-.root :global p {
+.root :global .text {
   color: brown;
   font-size: 24px;
   font-family: helvetica, arial, sans-serif;

--- a/src/components/2-GlobalSelectors/GlobalSelectors.js
+++ b/src/components/2-GlobalSelectors/GlobalSelectors.js
@@ -7,7 +7,7 @@ export default class GlobalSelectors extends Component {
   render() {
     return (
       <div className={ styles.root }>
-        <p>Global Selectors</p>
+        <p className="text">Global Selectors</p>
       </div>
     );
   }


### PR DESCRIPTION
As far as I can tell `css-modules` locally scope class selectors but not element selectors in from the component css file. This means that the `GlobalSelectors` example is slightly misleading since:

``` css
.root :global p {
  ...
}
```

and

``` css
.root p {
  ...
}
```

Both have the result of styling all the `p` tags inside the elements with the `.root` class applied. This is slightly surprising since the entire point of the example is to demonstrate how `:global` works.

Updating the example to use a, semantically meaningless, class makes things clearer for people going through the examples.

As far as I can tell the `:global` would be most useful if you were to be using css modules with an existing non-modular framework (perhaps like bootstrap) and you wanted to override some styles for your component. I might be way off base though.
