### PR TITLE
Remove autoprefixer-core dependency in favor of autoprefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/css-modules/webpack-demo",
   "devDependencies": {
-    "autoprefixer-core": "^5.1.11",
+    "autoprefixer": "^5.1.11",
     "babel-core": "^5.2.17",
     "babel-loader": "^5.0.0",
     "css-loader": "^0.15.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = {
   },
 
   postcss: [
-    require('autoprefixer-core'),
+    require('autoprefixer'),
     require('postcss-color-rebeccapurple')
   ],
 


### PR DESCRIPTION
When using autoprefixer with postcss, the `autoprefixer` package is preferred versus the `autoprefixer-core` package which is now deprecated. This change is just a simple change to the dependencies of the project and updating the corresponding postcss configuration.
