### PR TITLE
Replace autoprefixer-core(deprecated) with autoprefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,23 +21,23 @@
   },
   "homepage": "https://github.com/css-modules/webpack-demo",
   "devDependencies": {
-    "autoprefixer-core": "^5.1.11",
+    "autoprefixer": "^6.1.1",
     "babel-core": "^5.2.17",
     "babel-loader": "^5.0.0",
-    "css-loader": "^0.15.1",
+    "css-loader": "^0.23.0",
     "ejs": "^2.3.1",
     "extract-text-webpack-plugin": "^0.8.1",
     "file-loader": "^0.8.4",
     "gh-pages": "git://github.com/markdalgleish/gh-pages#cli-message",
     "node-libs-browser": "^0.5.0",
     "postcss-color-rebeccapurple": "^1.1.0",
-    "postcss-loader": "^0.4.3",
+    "postcss-loader": "^0.8.0",
     "raw-loader": "^0.5.1",
     "react": "^0.13.3",
     "react-to-html-webpack-plugin": "^2.2.0",
     "style-loader": "^0.12.3",
     "url-loader": "^0.5.6",
     "webpack": "^1.9.10",
-    "webpack-dev-server": "^1.9.0"
+    "webpack-dev-server": "^1.12.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = {
   },
 
   postcss: [
-    require('autoprefixer-core'),
+    require('autoprefixer'),
     require('postcss-color-rebeccapurple')
   ],
 


### PR DESCRIPTION
This commit replaces the deprecated autoprefixer-core (https://github.com/ai/autoprefixer-core) with autoprefixer. Had to update a few other devDependencies to get it working again.
