### PR TITLE
Update Readme to resolve omitted -loader extension error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To make CSS modules work with Webpack you only have to include the modules menti
 . . .
 {
   test: /\.css$/,
-  loader: 'style!css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]' 
+  loader: 'style-loader!css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]' 
 }
 . . .
 ```


### PR DESCRIPTION
Per:
https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed