### PR TITLE
Fix in README for Webpack2

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To make CSS modules work with Webpack you only have to include the modules menti
 . . .
 {
   test: /\.css$/,
-  loader: 'style!css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]' 
+  loader: 'style-loader!css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]' 
 }
 . . .
 ```


### PR DESCRIPTION
Tried to follow the instructions in README, and got this error:

```
ERROR in ./path/to/index.js
Module not found: Error: Can't resolve 'style' in '/path/to/project'
BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.
                 You need to specify 'style-loader' instead of 'style',
                 see https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed
```

Renaming `style` to `style-loader` worked for me.