### PR TITLE
docs: fix demo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A working demo of [CSS Modules], using [Webpack]'s [css-loader] in [module mode]
 
 ```bash
 $ npm install
-$ npm start & open http://localhost:8080
+$ npm start & open http://localhost:8080/webpack-dev-server/
 ```
 
 ## npm modules required for CSS modules


### PR DESCRIPTION
Noticed this is off when running the demo.